### PR TITLE
Added feature to allow for SIP multi tenancy.

### DIFF
--- a/Examples/ConsoleIvr/Program.cs
+++ b/Examples/ConsoleIvr/Program.cs
@@ -16,22 +16,21 @@ namespace ConsoleIvr
         //private static ILine line2;
         private static bool exit = false;
 
+
         static void Main(string[] args)
         {
 
-            //Starting a bunch of lines.
-
-            
+            int offset = Int32.Parse(VoiceProperties.Current.GetProperty("sip.channel_offset"));
 
             //Thread waitThread = new Thread(new ThreadStart(WaitCall));
-            int LineNumber = 1;
+            int LineNumber = 1 + offset;
             Console.WriteLine("Start Line {0}", LineNumber);
             Thread waitThread = new Thread(() => WaitCall(LineNumber));
             waitThread.Start();
             while (!waitThread.IsAlive) ;
             Thread.Sleep(10000);
 
-            LineNumber = 2;
+            LineNumber = 2 + offset;
             Console.WriteLine("Start Line {0}", LineNumber);
             //Thread makeCallThread = new Thread(new ThreadStart(MakeCall));
             Thread makeCallThread = new Thread(() => MakeCall(LineNumber));
@@ -78,7 +77,7 @@ namespace ConsoleIvr
             Console.WriteLine("################################MakeCall: Line {0}: Got Line", LineNumber);
             while (!exit)
             {
-                Thread.Sleep(300000);
+               
 
                 try
                 {
@@ -88,10 +87,17 @@ namespace ConsoleIvr
                     Thread.Sleep(1000);
                     Console.WriteLine("MakeCall: Line {0}: Dial", LineNumber);
                     CallAnalysis result = line2.Dial("7782320255", 3500);
-                    line2.PlayFile("System Recordings\\Thursday.wav");
+                    if (LineNumber >= 4) {
+                        line2.PlayFile("System Recordings\\Monday.wav");
+                    }
+                    else
+                    {
+                        line2.PlayFile("System Recordings\\Thursday.wav");
+                    }
 
                     //line2.RecordToFile("C:\\ads\\data\\database\\E15226.wav");
                     line2.Hangup();
+                    Thread.Sleep(60000);
 
                 }
                 catch (ivrToolkit.Core.Exceptions.HangupException)
@@ -99,6 +105,7 @@ namespace ConsoleIvr
                     line2.Hangup();
 
                 }
+                Thread.Sleep(300000);
             }
             Console.WriteLine("MakeCall: Line {0}: End of Make Call", LineNumber);
             line2.Close();

--- a/Examples/ConsoleIvr/voice.properties
+++ b/Examples/ConsoleIvr/voice.properties
@@ -73,8 +73,11 @@ cap.ca_maxansr=1000
 #
 # sip parameters
 #
+sip.channel_offset=0
+sip.h323_signaling_port=1720
+sip.sip_signaling_port=5060
 sip.proxy_ip=10.143.102.42
 sip.local_ip=10.143.102.220
-sip.alias=Developer1
+sip.alias=Developer2
 sip.password=password
 sip.realm=

--- a/Examples/ConsoleSipSync/Program.cs
+++ b/Examples/ConsoleSipSync/Program.cs
@@ -83,7 +83,7 @@ namespace ConsoleSipSync
         {
 
             sip = new DialogicSIPSync();
-            sip.WStartLibraries();
+            sip.WStartLibraries(1720,5060);
 
             SIPThread sipThreadOne = new SIPThread();
 
@@ -120,7 +120,7 @@ namespace ConsoleSipSync
                         break;
                     case CLI_QUIT:
                         sip.WClose();
-                        sip.WStartLibraries();
+                        sip.WStartLibraries(1720,5060);
                         exitLoop = true;
                         break;
                     case CLI_MAKECALL:

--- a/Examples/ConsoleSipSync/SIPThread.cs
+++ b/Examples/ConsoleSipSync/SIPThread.cs
@@ -107,7 +107,7 @@ namespace ConsoleSipSync
                         break;
                     case CLI_QUIT:
                         sip.WClose();
-                        sip.WStartLibraries();
+                        sip.WStartLibraries(1720,5060);
                         exitLoop = true;
                         break;
                     case CLI_MAKECALL:

--- a/ivrToolkit.Core/Util/TenantSingleton.cs
+++ b/ivrToolkit.Core/Util/TenantSingleton.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace ivrToolkit.Core.Util
+{
+    public class TenantSingleton
+    {
+        private static TenantSingleton instance;
+        private string _tenantDirectory;
+        private string _tenant = "";
+
+        private TenantSingleton() {
+
+            String[] args = Environment.GetCommandLineArgs();
+
+            foreach (string s in args)
+            {
+                if (s.StartsWith("-t"))
+                {
+                    _tenant = s.Substring(2);
+                }
+            }
+
+            var location = System.Reflection.Assembly.GetExecutingAssembly().Location;
+            location = Path.GetDirectoryName(location);
+            if (location == null) throw new Exception("Executable path not found");
+
+            if ((_tenant == null) || (_tenant.Trim().Equals("")))
+            {
+                _tenantDirectory = location;
+            }
+            else
+            {
+                _tenantDirectory = Path.Combine(location, _tenant);
+            }
+        }
+
+        public static TenantSingleton Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    instance = new TenantSingleton();
+                }
+                return instance;
+            }
+        }
+
+        public string TenantDirectory
+        {
+            get
+            {
+                return _tenantDirectory;
+            }
+        }
+
+        public string Tenant {
+            get
+            {
+                return _tenant;
+            }
+        }
+    }
+}

--- a/ivrToolkit.Core/Util/VoiceProperties.cs
+++ b/ivrToolkit.Core/Util/VoiceProperties.cs
@@ -6,6 +6,7 @@
 // 
 using System;
 using ivrToolkit.Core.Exceptions;
+using System.IO;
 
 namespace ivrToolkit.Core.Util
 {
@@ -29,7 +30,10 @@ namespace ivrToolkit.Core.Util
 
         private VoiceProperties()
         {
-            _p = new Properties("voice.properties");
+
+            string tenantDirectory = TenantSingleton.Instance.TenantDirectory;
+            var path = Path.Combine(tenantDirectory, "voice.properties");
+            _p = new Properties(path);
         }
 
         /// <summary>
@@ -95,6 +99,40 @@ namespace ivrToolkit.Core.Util
         /// if true then the dial method will check for dial tone after picking up the receiver/dialing the number.
         /// </summary>
         public bool PreTestDialTone { get { return ToBool(_p.GetProperty("dial.preTestDialTone", "true")); } }
+        /// <summary>
+        /// Number to add the line in order to get the channel.
+        /// </summary>
+        public int SipChannelOffset { get { return int.Parse(_p.GetProperty("sip.channel_offset", "0")); } }
+        /// <summary>
+        /// The SIP port used for H323 signaling
+        /// </summary>
+        public int SipH323SignalingPort { get { return int.Parse(_p.GetProperty("sip.h323_signaling_port", "1720")); } }
+        /// <summary>
+        /// The SIP port used for SIP signaling
+        /// </summary>
+        public int SipSignalingPort { get { return int.Parse(_p.GetProperty("sip.sip_signaling_port", "5060")); } }
+        /// <summary>
+        /// The SIP proxy ip address.  This is the address of the PBX that will be used to connect to the SIP Trunk.
+        /// </summary>
+        public string SipProxyIp { get { return _p.GetProperty("sip.proxy_ip", "10.143.102.42"); } }
+        /// <summary>
+        /// The SIP local ip address.  This is the address of the server that runs this program.
+        /// </summary>
+        public string SipLocalIp { get { return _p.GetProperty("sip.local_ip", "127.0.0.1"); } }
+        /// <summary>
+        /// The SIP account on the PBX server. This is the account that will be used to make and receive calls for this ADS SIP instance.
+        /// </summary>
+        public string SipAlias { get { return _p.GetProperty("sip.alias", "SipAccount"); } }
+        /// <summary>
+        /// The SIP password for the SipAlias on the PBX server. 
+        /// </summary>
+        public string SipPassword { get { return _p.GetProperty("sip.password", "password"); } }
+        /// <summary>
+        /// The SIP realm for the SipAlias on the PBX server. 
+        /// </summary>
+        public string SipRealm { get { return _p.GetProperty("sip.realm", ""); } }
+
+
         /// <summary>
         /// The definition of dial tone. Default is '350,20,440,20,L'. The default Tone Id is '306'.
         /// </summary>

--- a/ivrToolkit.Core/ivrToolkit.Core.csproj
+++ b/ivrToolkit.Core/ivrToolkit.Core.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Util\Prompt.cs" />
     <Compile Include="Util\PromptFunctions.cs" />
     <Compile Include="Util\Properties.cs" />
+    <Compile Include="Util\TenantSingleton.cs" />
     <Compile Include="Util\VoiceProperties.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/ivrToolkit.DialogicSipLibrary/hmp_sip.cpp
+++ b/ivrToolkit.DialogicSipLibrary/hmp_sip.cpp
@@ -1072,7 +1072,7 @@ int print_all_cclibs_status(void)
 /**
 * Start the Dialogic Global Call API and initalize the libraries.
 */
-void global_call_start()
+void global_call_start(int h323_signaling_port, int sip_signaling_port)
 {
 	GC_START_STRUCT	gclib_start;
 	IPCCLIB_START_DATA cclib_start_data;
@@ -1093,8 +1093,10 @@ void global_call_start()
 
 	virt_boards[0].localIP.ip_ver = IPVER4;					// must be set to IPVER4
 	virt_boards[0].localIP.u_ipaddr.ipv4 = IP_CFG_DEFAULT;	// or specify host NIC IP address
-	virt_boards[0].h323_signaling_port = IP_CFG_DEFAULT;	// or application defined port for H.323 
-	virt_boards[0].sip_signaling_port = IP_CFG_DEFAULT;		// or application defined port for SIP
+	//virt_boards[0].h323_signaling_port = IP_CFG_DEFAULT;	// or application defined port for H.323 
+	//virt_boards[0].sip_signaling_port = IP_CFG_DEFAULT;		// or application defined port for SIP
+	virt_boards[0].h323_signaling_port = h323_signaling_port;	// or application defined port for H.323 
+	virt_boards[0].sip_signaling_port = sip_signaling_port;		// or application defined port for SIP
 	virt_boards[0].sup_serv_mask = IP_SUP_SERV_CALL_XFER;	// Enable SIP Transfer Feature
 	virt_boards[0].sip_msginfo_mask = IP_SIP_MSGINFO_ENABLE;// Enable SIP header
 	virt_boards[0].reserved = NULL;							// must be set to NULL
@@ -1128,7 +1130,7 @@ void open_channels()
 	long request_id = 0;
 	GC_PARM_BLKP gc_parm_blk_p = NULL;
 
-	global_call_start();
+	global_call_start(H323_SIP_PORT, HMP_SIP_PORT);
 	printf("global_call_start() done.\n");
 
 	//enum_dev_information();
@@ -1726,9 +1728,9 @@ void WaitEvent(void* parm)
 /**
 * Starts Dialogic Libraries syncronously
 */
-void DialogicFunctions::DialogicStartSync(){
+void DialogicFunctions::DialogicStartSync(int h323_signaling_port, int sip_signaling_port){
 	if (!started){
-		global_call_start();
+		global_call_start(h323_signaling_port, sip_signaling_port);
 	}
 
 }

--- a/ivrToolkit.DialogicSipLibrary/hmp_sip.h
+++ b/ivrToolkit.DialogicSipLibrary/hmp_sip.h
@@ -5,6 +5,7 @@
 
 #define USER_DISPLAY					"SRB-Education"
 #define USER_AGENT	"SRB_SIP_CLIENT"
+#define H323_SIP_PORT					1720
 #define HMP_SIP_PORT					5060
 #define SYNC_WAIT_INFINITE -1
 #define SYNC_WAIT_EXPIRED -2
@@ -24,7 +25,7 @@ public:
 	* 
 	*/
 	/*Start Functions*/
-	void DialogicStartSync();
+	void DialogicStartSync(int h323_signaling_port, int sip_signaling_port);
 	void DialogicStopSync();
 	/*Channel Functions*/
 	void DialogicOpenSync(int channel_index);

--- a/ivrToolkit.DialogicSipPluginSync/DialogicLibrary.cs
+++ b/ivrToolkit.DialogicSipPluginSync/DialogicLibrary.cs
@@ -10,10 +10,10 @@ namespace ivrToolkit.DialogicSipPluginSync
 {
     class DialogicLibrary : ILibrary
     {
-        public void StartLibraries()
+        public void StartLibraries(int h323_signaling_port, int sip_signaling_port)
         {
             DialogicSIPSync sip = new DialogicSIPSync();
-            sip.WStartLibraries();
+            sip.WStartLibraries(h323_signaling_port, sip_signaling_port);
         }
         public void StopLibraries()
         {

--- a/ivrToolkit.DialogicSipPluginSync/ILibrary.cs
+++ b/ivrToolkit.DialogicSipPluginSync/ILibrary.cs
@@ -8,7 +8,7 @@ namespace ivrToolkit.DialogicSipPluginSync
     public interface ILibrary
     {
 
-        void StartLibraries();
+        void StartLibraries(int h323_signaling_port, int sip_signaling_port);
         void StopLibraries();
 
     }

--- a/ivrToolkit.DialogicSipWrapperSync/DialogicWrapperSync.cpp
+++ b/ivrToolkit.DialogicSipWrapperSync/DialogicWrapperSync.cpp
@@ -23,8 +23,8 @@ DialogicWrapperSync::DialogicSIPSync::!DialogicSIPSync(){
 	delete dialogicFunctions;
 }
 
-void DialogicWrapperSync::DialogicSIPSync::WStartLibraries(){
-	dialogicFunctions->DialogicStartSync();
+void DialogicWrapperSync::DialogicSIPSync::WStartLibraries(int h323_signaling_port, int sip_signaling_port){
+	dialogicFunctions->DialogicStartSync(h323_signaling_port, sip_signaling_port);
 }
 void DialogicWrapperSync::DialogicSIPSync::WStopLibraries(){
 	dialogicFunctions->DialogicStopSync();

--- a/ivrToolkit.DialogicSipWrapperSync/DialogicWrapperSync.h
+++ b/ivrToolkit.DialogicSipWrapperSync/DialogicWrapperSync.h
@@ -22,7 +22,7 @@ namespace DialogicWrapperSync {
 		!DialogicSIPSync();
 
 		//wrapper methods
-		void WStartLibraries();
+		void WStartLibraries(int h323_signaling_port, int sip_signaling_port);
 		void WStopLibraries();
 		void WOpen(int channel_index);
 		void WClose();


### PR DESCRIPTION
These updated will enable ADS SIP to enable multi tenancy by using a command line parameter -t to specify the tenant sub directory for the voice.properties file.