### PR TITLE
Checks if the call has been hungup in the play file logic and rethrow…

### DIFF
--- a/ivrToolkit.DialogicSipPluginSync/Dialogic.cs
+++ b/ivrToolkit.DialogicSipPluginSync/Dialogic.cs
@@ -628,10 +628,10 @@ namespace ivrToolkit.DialogicSipPluginSync
         private static void CheckCallState(DialogicSIPSync sip)
         {
                     int call_state = sip.WGetCallState();
-                    Console.WriteLine("Call State {0}", call_state);
+                    Logger.Info("CheckCallState : Call State {0}", call_state);
                     if (call_state != 4)
                     {
-                        Console.WriteLine("The call has been hang up.");
+                        Logger.Info("CheckCallState : The call has been hang up.");
                         throw new HangupException();
 
                     }
@@ -854,7 +854,16 @@ namespace ivrToolkit.DialogicSipPluginSync
                 //}
 
                 //Check if the call is still connected
-                CheckCallState(sip);
+                try
+                {
+                    CheckCallState(sip);
+                }
+                catch (HangupException)
+                {
+                    dx_fileclose(iott.io_fhandle);
+                    Logger.Info("Hangup Exception : The file handle has been closed because the call has been hung up.");
+                    throw new HangupException("Hangup Exception call has been hungup.");
+                }
 
                 var type = sr_getevttype((uint)handler);
                 //Ignore events (including timeout events) that are not of they type we want.


### PR DESCRIPTION
The file handle in the play file logic was not being closed correctly if the call had been hung up while the file was being played.  

This corrects the issue by catching the exception thrown when checking If the call has been hung-up in the play file logic.  The exception is re-thrown by the play file logic.  
